### PR TITLE
Add OC guides to GitHub

### DIFF
--- a/guides/build-api-plugin.md
+++ b/guides/build-api-plugin.md
@@ -1,0 +1,235 @@
+## At a glance
+
+Mailchimp Open Commerce has a plugin system that allows you to extend or replace any of the features offered by the core platform. You can add plugins written by the Open Commerce community, or you can create your own. The plugins that you register will determine the exact functionality of your API.
+
+You can use plugins to:
+
+  * Add new types of information to products
+
+  * Accept payments or ship orders with your preferred provider
+
+  * Validate customers’ addresses when they check out
+
+For the purposes of this guide, we manage the Open Commerce store for Leader of the Pack, an outdoor supplier that sells backpacks, among other things. We currently list fairly standard product dimensions—length, width, height—but recently, our customers have been asking just how much stuff they can fit in our backpacks. To answer their questions, we’ve decided to add a `volume` attribute to those products in our store.
+
+In this guide, we’ll create a new plugin from the template provided by Open Commerce and register it with the platform running in development mode. Then we’ll set up the volume field and add it to the schemas for our products. Finally, we’ll extend the GraphQL API so our new field is available across our store.
+
+## What you’ll need
+
+  * An [Open Commerce installation](/developer/open-commerce/guides/quick-start/)
+
+  * [Docker](https://www.docker.com/)
+
+  * [npm](https://www.npmjs.com/get-npm)
+
+  * A [GitHub](https://github.com/) account
+
+## Clone the example plugin template
+
+We’ll be creating a plugin that extends our products schema to include a `volume` attribute for our backpacks. To build our custom plugin, we’ll first create our own repo from the [Example Plugin template on GitHub](https://github.com/reactioncommerce/api-plugin-example/) and then clone the new plugin to our working directory. (Cloning to `reaction-development-platform/api-plugins` is recommended but not required.)
+
+Next, we’ll edit the `package.json` and `src/index.js` files to replace the template defaults with information about our volume attribute plugin; the information in these files will be used when linking, installing, and registering the plugin. We’ll name our plugin Product Volume, with an npm name of `@leaderpack/api-plugin-products-volume`.
+
+> **Note**: To keep things organized, it’s a good idea to name plugins after their “parent” plugins. In our case, we’re customizing aspects of `api-plugin-products`, so we named our plugin `api-plugin-products-volume`.
+
+## Link the plugin
+
+Next we have to load our new plugin by linking it inside the Open Commerce Docker container. While you can do this in production mode, it’s better to do it in development mode, which allows you to add and remove plugins on the fly. 
+
+To enable development mode, navigate to your `reaction-development-platform` directory and run `make dev-reaction`.
+
+> **Note**: Starting development mode takes a couple minutes—much longer than production mode. Development mode builds an editable Docker image on demand, while production mode uses an uneditable, pre-built image. 
+
+From here, we’ll change directories to `reaction-development-platform/reaction` and add our plugin to the list in `plugins.json`: 
+
+### plugins.json
+
+```json
+{
+  ...
+  "productsVolume": "@leaderpack/api-plugin-products-volume",
+  ...
+}
+```
+    
+    
+To link our plugin to the Open Commerce API Docker container, we’ll run `bin/package-link api-plugin-products-volume`. If you need to link a plugin that is not in the `api-plugins` folder, add the path to your plugin as the second argument of `bin/package-link`.
+
+The API will restart automatically with the new plugin loaded and ready to use. When you make edits to a plugin in development mode, the Open Commerce API service will automatically refresh to reflect those edits. 
+
+You can verify that the plugin has loaded in the logs by running `docker-compose logs -f api`, or in the admin dashboard under **Settings > System information**.
+
+## Add functions
+
+So we know that our new plugin is running, but we haven’t programmed it to do anything yet. Now we can start to add functionality—and since Open Commerce is in development mode, our plugin will reload every time we modify it.
+
+Open Commerce offers several ways to [extend its functionality and API](/developer/open-commerce/docs/sharing-code-between-plugins/). Our plugin will use two approaches: `functionsByType`, which overrides or extends existing functions, and `graphQL`, which adds queries and mutations to the GraphQL API. 
+
+Since our goal is to add a `volume` attribute to product variants, we’ll need to extend the existing product and catalog SimpleSchema to include this new field. First, we’ll add a startup function to extend the two SimpleSchemas, allowing them to be validated and saved to MongoDB:
+
+```node title="startup.js"
+function myStartup(context) {
+  context.simpleSchemas.ProductVariant.extend({
+	volume: {
+	  type: Number,
+	  min: 0,
+	  optional: true
+	}
+  });
+
+  context.simpleSchemas.CatalogProductVariant.extend({
+	volume: {
+	  type: Number,
+	  min: 0,
+	  optional: true
+	}
+  })
+}
+```
+
+We’ll also extend the function that publishes products to the catalog, adding extra steps to `publishProductToCatalog`. The new `myPublishProductToCatalog` function parses our products, gets the new `volume` attribute, and adds it to the corresponding catalog variant in preparation for publishing it to the catalog:
+
+```node title="index.js"
+function myPublishProductToCatalog(catalogProduct, { context, product, shop, variants }) {
+ catalogProduct.variants && catalogProduct.variants.map((catalogVariant) => {
+   const productVariant = variants.find((variant) => variant._id === catalogVariant.variantId);
+   catalogVariant.volume = productVariant.volume || null;
+ });
+}
+```
+
+Then we’ll instruct the `catalogs` plugin to looks for the `myPublishProductToCatalog` function by type, making it the key to communicating data from the new field to the catalog:
+
+```node title="index.js"
+export default async function register(app) {
+  await app.registerPlugin({
+	label: "Product Dimensions",
+	name: "products-dimensions",
+	version: pkg.version,
+	functionsByType: {
+	  startup: [myStartup]
+	  publishProductToCatalog: [myPublishProductToCatalog]
+	},
+  });
+}
+```
+
+## Extend the GraphQL API
+
+Our custom plugin is linked, registered, and has a startup function, so now it’s time to extend the GraphQL API. We’ll do that by creating a `schema.graphql` file in the plugin’s `src/` directory and adding type extensions:
+
+```graphql title="schema.graphql"
+extend type ProductVariant {
+  volume: Float
+}
+
+extend input ProductVariantInput {
+  volume: Float
+}
+
+extend type CatalogProductOrVariant {
+  volume: Float
+}
+```
+
+Back in our plugin’s `src/index.js` file, we can import the new schema using `importAsString` and add it to the `app.registerPlugin` options:
+
+```node title="src/index.js"
+
+import importAsString from “@reactioncommerce/api-utils/importAsString.js”;
+
+const mySchema = importAsString(“./schema.graphql”);
+
+export default async function register(app) {
+  await app.registerPlugin({
+	label: "Product Dimensions",
+	name: "products-dimensions",
+	version: pkg.version,
+	functionsByType: {
+	  startup: [myStartup]
+	  publishProductToCatalog: [myPublishProductToCatalog]
+	},
+	graphQL: {
+	  schemas: [mySchema]
+	}
+  });
+}
+```
+
+That’s it! We can see the plugin in action by using a GraphQL mutation to update a product variant with a `volume` attribute:
+
+```graphql title="Mutation"
+mutation {
+  updateProductVariant(input: {
+	variantId: "{encoded-variant-id}",
+	shopId: "{encoded-shop-id}",
+	variant: {
+	  volume: 200
+	}
+  }) {
+	variant {
+	  volume
+	}
+  }
+}
+
+```
+
+```graphql title="Response"
+{
+  "data": {
+	"updateProductVariant": {
+	  "variant": {
+		"volume": 200
+	  }
+	}
+  }
+}
+
+```
+
+And once that variant is published, the new `volume` field will be available on the catalog product, thanks to the `publishProductToCatalog` function:
+
+```graphql title="Query"
+query {
+  catalogItemProduct(
+	shopId: "{encoded-shop-id}",
+	slugOrId: "{encoded-slug-or-id}") {
+	product {
+	  variants {
+		volume
+	  }
+	}
+  }
+}
+ 
+```
+
+
+```graphql title="Response"
+{
+  "data": {
+	"catalogItemProduct": {
+	  "product": {
+		"variants": [
+		  {
+			"volume": 200
+		  }
+		]
+	  }
+	}
+  }
+}
+
+```
+
+We’ve done everything we need to add volume data to our backpacks and query that information across our store. That’s useful to Leader of the Pack’s store administrators, but we also need to get that information to customers. This will require some design work on our product pages, which are dependent on the storefront plugin that we’re using. Generally, this will involve making sure that our product query includes the new `volume` field and that the information is passed to the `render()` function in the file that describes our product detail page. For more information, see the [Creating and Organizing Products doc](/developer/open-commerce/docs/creating-organizing-products/).
+
+## More resources
+
+  * [Sharing Code Between Plugins](/developer/open-commerce/docs/sharing-code-between-plugins/)
+
+  * [GraphQL Playground](/developer/open-commerce/playground/)
+
+  * [Open Commerce Fundamentals](/developer/open-commerce/docs/fundamentals/)
+

--- a/guides/quick-start.md
+++ b/guides/quick-start.md
@@ -1,0 +1,61 @@
+## At a glance
+
+There are two main routes to getting started with Mailchimp Open Commerce: installing the platform on your local computer or on a server. This guide will focus on the former, which will allow you to explore the main features of Open Commerce.
+
+In this guide, we’ll set up a full local instance of the Open Commerce platform, including core plugins provided by Mailchimp. We’ll walk through cloning and starting the Open Commerce development platform, registering an account, and creating your first shop. 
+
+## What you’ll need
+
+  * [Docker](https://www.docker.com/)
+
+  * [Docker Compose](https://docs.docker.com/compose/)
+
+  * Windows users: [WSL 2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and [Docker for WSL](https://docs.docker.com/docker-for-windows/wsl/)
+
+## Clone and start the platform
+
+The simplest way to get an instance up and running on your local machine is by using the [development platform](https://github.com/reactioncommerce/reaction-development-platform), a set of `make` scripts that coordinates all of the different pieces of the Open Commerce software system. 
+
+To set up the Open Commerce development platform, navigate to a Unix or WSL directory and run:
+
+```bash
+git clone https://github.com/reactioncommerce/reaction-development-platform.git
+cd reaction-development-platform
+make
+```    
+    
+> **Note**: On Windows, you may need to replace `make` with `sudo make`. Then run `chown -R` on the `reaction-development-platform` directory to set your user as the owner of all the files it contains.
+
+Behind the scenes, the `make` process clones all of the relevant Open Commerce software repositories, sets up each environment, and pulls, builds, and starts each Docker container. 
+
+When `make` completes, five services will be running on `localhost`:
+
+  * Open Commerce API (port 3000), including the [core plugins](/developer/open-commerce/docs/fundamentals/#plugins). This service also contains the GraphQL playground at `localhost:3000/graphql`.
+
+  * [Example Storefront](https://github.com/reactioncommerce/example-storefront) (port 4000), which is built with [Next.js](https://nextjs.org/).
+
+  * [Admin dashboard](https://github.com/reactioncommerce/reaction-admin) (port 4080), used to manage shop settings, accounts, products, and orders.
+
+  * [Identity](https://github.com/reactioncommerce/reaction-identity) (port 4100), which handles Open Commerce customer and shop manager accounts.
+
+  * [Hydra OAuth2 Server](https://github.com/reactioncommerce/reaction-hydra) (port 4444), which can connect to external user accounts.
+
+> **Note**: You can manage individual pieces of the system by changing directories into a subproject and running Docker compose commands (e.g., `cd reaction-admin && docker-compose logs -f`).
+
+## Access the dashboard, playground, and storefront
+
+After the `make` command finishes provisioning the system, you can create a shop manager account for your local instance. 
+
+First, visit the Open Commerce login page at `localhost:4080`. Click **Register** and enter your email address and create a password, which will grant you admin privileges.
+
+Next, log in with your new account to access the shop creation form. Enter a name for your shop and click the **Create Shop** button. You should now see the Open Commerce admin dashboard, from which you can [create products](/developer/open-commerce/docs/creating-organizing-products/), [add tags](/developer/open-commerce/docs/tags-navigation/), and [manage your orders](/developer/open-commerce/docs/fulfilling-orders/).
+
+Once you've created a shop, you can visit the GraphQL playground at `localhost:3000/graphql`, where you can run test GraphQL queries and mutations. In the **Docs** tab of the playground, you can view the complete Open Commerce GraphQL API reference. 
+
+You can also view your Open Commerce storefront at `localhost:4000`.
+
+## Next steps
+
+Now that you’re up and running, you can start managing your store by creating products or building a custom storefront on top of the GraphQL API. The local instance also provides everything you need to code your own plugins for use with Open Commerce; for more information, see the [Build an API Plugin](/developer/open-commerce/guides/build-api-plugin/) guide.
+
+When you’re done exploring Open Commerce, navigate to your `reaction-development-platform` directory and run `make stop`. This ensures that Docker properly saves all your data for the next time you want to run the system. To restart the system, simply run `make` again in the same directory.


### PR DESCRIPTION
This creates a directory called `guides` to house the two Open Commerce guides in the same way that documentation already does.

Will need a review by Ed Cormany to make sure it cuts the mustard.